### PR TITLE
Create Load and dumps subcommands

### DIFF
--- a/src/apps/cmd/dumps.cr
+++ b/src/apps/cmd/dumps.cr
@@ -8,27 +8,12 @@ require "../../config"
 class CrystalTwin::Cmd::Dumps
   @@data_path
   @@model
-  @@persons_path
-  @@circles_path
-  @@topics_path
-  @@epics_path
-  @@sites_path
 
-  def self.config(data_path : String = "#{__DIR__}/../../../dumped_data", socketfile = "/tmp/bcdb.sock", namespace = "crystaltwin")
+  def self.config(data_path : String = "#{__DIR__}/../../../data", socketfile = "/tmp/bcdb.sock", namespace = "crystaltwin")
     @@model = "*"
-    @@data_path = data_path
-    @@persons_path = Path.new(@@data_path.to_s, "persons")
-    @@circles_path = Path.new(@@data_path.to_s, "circles")
-    @@topics_path = Path.new(@@data_path.to_s, "topics")
-    @@epics_path = Path.new(@@data_path.to_s, "epics")
-    @@sites_path = Path.new(@@data_path.to_s, "sites")
-    if !Dir.exists?(@@data_path.to_s)
+    @@data_path = Path.new(data_path)
+    if !Dir.exists?(@@data_path.as(Path))
       Dir.mkdir(@@data_path.to_s)
-      Dir.mkdir(@@persons_path.as(Path))
-      Dir.mkdir(@@circles_path.as(Path))
-      Dir.mkdir(@@topics_path.as(Path))
-      Dir.mkdir(@@epics_path.as(Path))
-      Dir.mkdir(@@sites_path.as(Path))
     end
     CrystalTwin::Config.set_db socketfile: socketfile, namespace: namespace
   end
@@ -48,82 +33,27 @@ class CrystalTwin::Cmd::Dumps
   end
 
   def self.dumps(overwrite_flag : Bool = false)
-    # Dumps Person Model
-    if @@model == "*" || @@model == "person"
-      persons_entries = CrystalTwin::Models::Person.list
-      persons_entries.each do |key|
-        file_path = @@persons_path.to_s + "/person#{key.to_s}.yaml"
-        if File.exists?(file_path) && !overwrite_flag
-          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
-        else
-          file = File.new(file_path, "w+")
-          person = CrystalTwin::Models::Person.get(key)
-          person.to_yaml(file)
-          log("Data dumped from database to #{File.basename(file_path)}",1)
+    # Loop on each model
+    CrystalTwin::Config.models.each do |model|
+      # Check if model equals to the model option
+      if @@model == "*" || @@model == model.basename
+        model_path = Path.new(@@data_path.as(Path),"#{model.basename}s")
+        if !Dir.exists?(model_path)
+          Dir.mkdir(model_path)
         end
-      end
-    end
-
-    # # Dumps Circle Model
-    if @@model == "*" || @@model == "circle"
-      circles_entries = CrystalTwin::Models::Circle.list
-      circles_entries.each do |key|
-        file_path = @@circles_path.to_s + "/cicle#{key.to_s}.yaml"
-        if File.exists?(file_path) && !overwrite_flag
-          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
-        else
-          file = File.new(file_path, "w+")
-          circle = CrystalTwin::Models::Circle.get(key)
-          circle.to_yaml(file)
-          log("Data dumped from database to #{File.basename(file_path)}",1)
-        end
-      end
-    end
-
-    # # Dumps Topic Model
-    if @@model == "*" || @@model == "topic"
-      topics_entries = CrystalTwin::Models::Topic.list
-      topics_entries.each do |key|
-        file_path = @@topics_path.to_s + "/topic#{key.to_s}.yaml"
-        if File.exists?(file_path) && !overwrite_flag
-          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
-        else
-          file = File.new(file_path, "w+")
-          topic = CrystalTwin::Models::Topic.get(key)
-          topic.to_yaml(file)
-          log("Data dumped from database to #{File.basename(file_path)}",1)
-        end
-      end
-    end
-
-    # # Dumps Epic Model
-    if @@model == "*" || @@model == "epics"
-      epics_entries = CrystalTwin::Models::Epic.list
-      epics_entries.each do |key|
-        file_path = @@epics_path.to_s + "/epic#{key.to_s}.yaml"
-        if File.exists?(file_path) && !overwrite_flag
-          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
-        else
-          file = File.new(file_path, "w+")
-          epic = CrystalTwin::Models::Epic.get(key)
-          epic.to_yaml(file)
-          log("Data dumped from database to #{File.basename(file_path)}",1)
-        end
-      end
-    end
-
-    # # Dumps Site Model
-    if @@model == "*" || @@model == "sites"
-      sites_entries = CrystalTwin::Models::Site.list
-      sites_entries.each do |key|
-        file_path = @@sites_path.to_s + "/site#{key.to_s}.yaml"
-        if File.exists?(file_path) && !overwrite_flag
-          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
-        else
-          file = File.new(file_path, "w+")
-          site = CrystalTwin::Models::Site.get(key)
-          site.to_yaml(file)
-          log("Data dumped from database to #{File.basename(file_path)}",1)
+        # List the keys of each model
+        model_objects = model.list
+        # Dump the data from database to yaml files 
+        model_objects.each do |key|
+          obj_path = Path.new(model_path,"#{model.basename}#{key.to_s}.yaml")
+          if File.exists?(obj_path) && !overwrite_flag
+            log("#{File.basename(obj_path)} is already exist\nplease add --overwrite to your command\n", 2)
+          else
+            obj_file = File.new(obj_path, "w+")
+            obj = model.get(key)
+            obj.to_yaml(obj_file)
+            log("Data dumped from database to #{File.basename(obj_path)}",1)
+          end
         end
       end
     end

--- a/src/apps/cmd/dumps.cr
+++ b/src/apps/cmd/dumps.cr
@@ -1,0 +1,131 @@
+require "yaml"
+require "json"
+require "bcdb"
+
+require "../models"
+require "../../config"
+
+class CrystalTwin::Cmd::Dumps
+  @@data_path
+  @@model
+  @@persons_path
+  @@circles_path
+  @@topics_path
+  @@epics_path
+  @@sites_path
+
+  def self.config(data_path : String = "#{__DIR__}/../../../dumped_data", socketfile = "/tmp/bcdb.sock", namespace = "crystaltwin")
+    @@model = "*"
+    @@data_path = data_path
+    @@persons_path = Path.new(@@data_path.to_s, "persons")
+    @@circles_path = Path.new(@@data_path.to_s, "circles")
+    @@topics_path = Path.new(@@data_path.to_s, "topics")
+    @@epics_path = Path.new(@@data_path.to_s, "epics")
+    @@sites_path = Path.new(@@data_path.to_s, "sites")
+    if !Dir.exists?(@@data_path.to_s)
+      Dir.mkdir(@@data_path.to_s)
+      Dir.mkdir(@@persons_path.as(Path))
+      Dir.mkdir(@@circles_path.as(Path))
+      Dir.mkdir(@@topics_path.as(Path))
+      Dir.mkdir(@@epics_path.as(Path))
+      Dir.mkdir(@@sites_path.as(Path))
+    end
+    CrystalTwin::Config.set_db socketfile: socketfile, namespace: namespace
+  end
+
+  def self.set_model(model = "*")
+    known_model_names = [] of String
+    known_model_names << "* -> All"
+    is_known_model = MODELS.find { |mod|
+      known_model_names << mod.basename
+      model == mod.basename || model == "*"
+    }
+    if is_known_model.nil?
+      err("Unknown Model,Please Enter one of the Following values #{known_model_names}")
+      exit 1
+    end
+    @@model = model
+  end
+
+  def self.dumps(overwrite_flag : Bool = false)
+    # Dumps Person Model
+    if @@model == "*" || @@model == "person"
+      persons_entries = CrystalTwin::Models::Person.list
+      persons_entries.each do |key|
+        file_path = @@persons_path.to_s + "/person#{key.to_s}.yaml"
+        if File.exists?(file_path) && !overwrite_flag
+          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
+        else
+          file = File.new(file_path, "w+")
+          person = CrystalTwin::Models::Person.get(key)
+          person.to_yaml(file)
+          log("Data dumped from database to #{File.basename(file_path)}",1)
+        end
+      end
+    end
+
+    # # Dumps Circle Model
+    if @@model == "*" || @@model == "circle"
+      circles_entries = CrystalTwin::Models::Circle.list
+      circles_entries.each do |key|
+        file_path = @@circles_path.to_s + "/cicle#{key.to_s}.yaml"
+        if File.exists?(file_path) && !overwrite_flag
+          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
+        else
+          file = File.new(file_path, "w+")
+          circle = CrystalTwin::Models::Circle.get(key)
+          circle.to_yaml(file)
+          log("Data dumped from database to #{File.basename(file_path)}",1)
+        end
+      end
+    end
+
+    # # Dumps Topic Model
+    if @@model == "*" || @@model == "topic"
+      topics_entries = CrystalTwin::Models::Topic.list
+      topics_entries.each do |key|
+        file_path = @@topics_path.to_s + "/topic#{key.to_s}.yaml"
+        if File.exists?(file_path) && !overwrite_flag
+          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
+        else
+          file = File.new(file_path, "w+")
+          topic = CrystalTwin::Models::Topic.get(key)
+          topic.to_yaml(file)
+          log("Data dumped from database to #{File.basename(file_path)}",1)
+        end
+      end
+    end
+
+    # # Dumps Epic Model
+    if @@model == "*" || @@model == "epics"
+      epics_entries = CrystalTwin::Models::Epic.list
+      epics_entries.each do |key|
+        file_path = @@epics_path.to_s + "/epic#{key.to_s}.yaml"
+        if File.exists?(file_path) && !overwrite_flag
+          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
+        else
+          file = File.new(file_path, "w+")
+          epic = CrystalTwin::Models::Epic.get(key)
+          epic.to_yaml(file)
+          log("Data dumped from database to #{File.basename(file_path)}",1)
+        end
+      end
+    end
+
+    # # Dumps Site Model
+    if @@model == "*" || @@model == "sites"
+      sites_entries = CrystalTwin::Models::Site.list
+      sites_entries.each do |key|
+        file_path = @@sites_path.to_s + "/site#{key.to_s}.yaml"
+        if File.exists?(file_path) && !overwrite_flag
+          log("#{File.basename(file_path)} is already exist\nplease add --overwrite to your command\n", 2)
+        else
+          file = File.new(file_path, "w+")
+          site = CrystalTwin::Models::Site.get(key)
+          site.to_yaml(file)
+          log("Data dumped from database to #{File.basename(file_path)}",1)
+        end
+      end
+    end
+  end
+end

--- a/src/apps/cmd/load.cr
+++ b/src/apps/cmd/load.cr
@@ -1,0 +1,118 @@
+require "yaml"
+require "json"
+require "bcdb"
+
+require "../models"
+require "../../config"
+
+class CrystalTwin::Cmd::Load
+  @@data_path
+  @@model
+  @@persons_path
+  @@circles_path
+  @@topics_path
+  @@epics_path
+  @@sites_path
+
+  def self.config(data_path : String = "#{__DIR__}/../../../data", socketfile = "/tmp/bcdb.sock", namespace = "crystaltwin")
+    @@model = "*"
+    @@data_path = data_path
+    @@persons_path = Path.new(@@data_path.to_s, "persons")
+    @@circles_path = Path.new(@@data_path.to_s, "circles")
+    @@topics_path = Path.new(@@data_path.to_s, "topics")
+    @@epics_path = Path.new(@@data_path.to_s, "epics")
+    @@sites_path = Path.new(@@data_path.to_s, "sites")
+    CrystalTwin::Config.set_db socketfile: socketfile, namespace: namespace
+  end
+
+  def self.set_model(model = "*")
+    known_model_names = [] of String
+    known_model_names << "* -> All"
+    is_known_model = MODELS.find { |mod|
+      known_model_names << mod.basename
+      model == mod.basename || model == "*"
+    }
+    if is_known_model.nil?
+      err("Unknown Model,Please Enter one of the Following values #{known_model_names}")
+      exit 1
+    end
+    @@model = model
+  end
+
+  def self.load (overwrite_flag : Bool = false)
+    # Load Person Model
+    if @@model == "*" || @@model == "person"
+      Dir.new(@@persons_path.as(Path)).each_child do |child|
+        path = Path.new(@@persons_path.to_s, child)
+        person = CrystalTwin::Models::Person.from_yaml(File.read(path))
+        if person.id == 0 || overwrite_flag
+          person.save
+          person.to_yaml(File.open(path,"w"))
+          log("#{path.basename} loaded to the database at entry ##{person.id}",1)
+        else
+          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
+        end
+      end
+    end
+
+    # Load Circle Model
+    if @@model == "*" || @@model == "circle"
+      Dir.new(@@circles_path.as(Path)).each_child do |child|
+        path = Path.new(@@circles_path.to_s, child)
+        circle = CrystalTwin::Models::Circle.from_yaml(File.read(path))
+        if circle.id == 0 || overwrite_flag
+          circle.save
+          circle.to_yaml(File.open(path,"w"))
+          log("#{path.basename} loaded to the database at entry ##{circle.id}",1)
+        else
+          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
+        end
+      end
+    end
+
+    # Load Topic Model
+    if @@model == "*" || @@model == "topic"
+      Dir.new(@@topics_path.as(Path)).each_child do |child|
+        path = Path.new(@@topics_path.to_s, child)
+        topic = CrystalTwin::Models::Topic.from_yaml(File.read(path))
+        if topic.id == 0 || overwrite_flag
+          topic.save
+          topic.to_yaml(File.open(path,"w"))
+          log("#{path.basename} loaded to the database at entry ##{topic.id}",1)
+        else
+          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
+        end
+      end
+    end
+
+    # Load Epic Model
+    if @@model == "*" || @@model == "epics"
+      Dir.new(@@epics_path.as(Path)).each_child do |child|
+        path = Path.new(@@epics_path.to_s, child)
+        epic = CrystalTwin::Models::Epic.from_yaml(File.read(path))
+        if epic.id == 0 || overwrite_flag
+          epic.save
+          epic.to_yaml(File.open(path,"w"))
+          log("#{path.basename} loaded to the database at entry ##{epic.id}",1)
+        else
+          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
+        end
+      end
+    end
+
+    # Load Site Model
+    if @@model == "*" || @@model == "sites"
+      Dir.new(@@sites_path.as(Path)).each_child do |child|
+        path = Path.new(@@sites_path.to_s, child)
+        site = CrystalTwin::Models::Site.from_yaml(File.read(path))
+        if site.id == 0 || overwrite_flag
+          site.save
+          site.to_yaml(File.open(path,"w"))
+          log("#{path.basename} loaded to the database at entry ##{site.id}",1)
+        else
+          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
+        end
+      end
+    end
+  end
+end

--- a/src/apps/cmd/load.cr
+++ b/src/apps/cmd/load.cr
@@ -8,20 +8,10 @@ require "../../config"
 class CrystalTwin::Cmd::Load
   @@data_path
   @@model
-  @@persons_path
-  @@circles_path
-  @@topics_path
-  @@epics_path
-  @@sites_path
 
   def self.config(data_path : String = "#{__DIR__}/../../../data", socketfile = "/tmp/bcdb.sock", namespace = "crystaltwin")
     @@model = "*"
-    @@data_path = data_path
-    @@persons_path = Path.new(@@data_path.to_s, "persons")
-    @@circles_path = Path.new(@@data_path.to_s, "circles")
-    @@topics_path = Path.new(@@data_path.to_s, "topics")
-    @@epics_path = Path.new(@@data_path.to_s, "epics")
-    @@sites_path = Path.new(@@data_path.to_s, "sites")
+    @@data_path = Path.new(data_path)
     CrystalTwin::Config.set_db socketfile: socketfile, namespace: namespace
   end
 
@@ -40,77 +30,29 @@ class CrystalTwin::Cmd::Load
   end
 
   def self.load (overwrite_flag : Bool = false)
-    # Load Person Model
-    if @@model == "*" || @@model == "person"
-      Dir.new(@@persons_path.as(Path)).each_child do |child|
-        path = Path.new(@@persons_path.to_s, child)
-        person = CrystalTwin::Models::Person.from_yaml(File.read(path))
-        if person.id == 0 || overwrite_flag
-          person.save
-          person.to_yaml(File.open(path,"w"))
-          log("#{path.basename} loaded to the database at entry ##{person.id}",1)
-        else
-          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
-        end
-      end
-    end
-
-    # Load Circle Model
-    if @@model == "*" || @@model == "circle"
-      Dir.new(@@circles_path.as(Path)).each_child do |child|
-        path = Path.new(@@circles_path.to_s, child)
-        circle = CrystalTwin::Models::Circle.from_yaml(File.read(path))
-        if circle.id == 0 || overwrite_flag
-          circle.save
-          circle.to_yaml(File.open(path,"w"))
-          log("#{path.basename} loaded to the database at entry ##{circle.id}",1)
-        else
-          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
-        end
-      end
-    end
-
-    # Load Topic Model
-    if @@model == "*" || @@model == "topic"
-      Dir.new(@@topics_path.as(Path)).each_child do |child|
-        path = Path.new(@@topics_path.to_s, child)
-        topic = CrystalTwin::Models::Topic.from_yaml(File.read(path))
-        if topic.id == 0 || overwrite_flag
-          topic.save
-          topic.to_yaml(File.open(path,"w"))
-          log("#{path.basename} loaded to the database at entry ##{topic.id}",1)
-        else
-          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
-        end
-      end
-    end
-
-    # Load Epic Model
-    if @@model == "*" || @@model == "epics"
-      Dir.new(@@epics_path.as(Path)).each_child do |child|
-        path = Path.new(@@epics_path.to_s, child)
-        epic = CrystalTwin::Models::Epic.from_yaml(File.read(path))
-        if epic.id == 0 || overwrite_flag
-          epic.save
-          epic.to_yaml(File.open(path,"w"))
-          log("#{path.basename} loaded to the database at entry ##{epic.id}",1)
-        else
-          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
-        end
-      end
-    end
-
-    # Load Site Model
-    if @@model == "*" || @@model == "sites"
-      Dir.new(@@sites_path.as(Path)).each_child do |child|
-        path = Path.new(@@sites_path.to_s, child)
-        site = CrystalTwin::Models::Site.from_yaml(File.read(path))
-        if site.id == 0 || overwrite_flag
-          site.save
-          site.to_yaml(File.open(path,"w"))
-          log("#{path.basename} loaded to the database at entry ##{site.id}",1)
-        else
-          log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
+    # Loop on all model directories in the data directory
+    Dir.new(@@data_path.as(Path)).each_child do |model_dir|
+      # Loop on each model
+      CrystalTwin::Config.models.each do |model|
+        # Check if model directory equals to the model directory and equals to the model option
+        if "#{model.basename}s" == model_dir && (@@model == "*" || "#{@@model}s" == model_dir)
+          model_path = Path.new(@@data_path.as(Path),model_dir)
+          # Loop on each file inside model directory and load it to the database
+          Dir.new(model_path.as(Path)).each_child do |child|
+            path = Path.new(model_path, child)
+            obj = model.from_yaml(File.read(path))
+            if obj.id == 0 # In case of new entry
+              obj.save
+              obj.to_yaml(File.open(path,"w"))
+              log("#{path.basename} loaded to the database as new entry ##{obj.id}",1)
+            elsif overwrite_flag # In case of old entry with overwrite option
+              obj.save
+              log("#{path.basename} update the database at entry ##{obj.id}",1)
+            else # In case of old entry without overwrite option
+              log("#{path.basename} already in the database\nplease add --overwrite to your command\n", 2)
+            end
+          end
+          break # To not loop on other models after found one.
         end
       end
     end

--- a/src/apps/models.cr
+++ b/src/apps/models.cr
@@ -81,19 +81,19 @@ abstract class CrystalTwin::Models::Model < CrystalTwin::Models::Parent
         return @{{prop.id}}
     end
     # Save/update object in bcdb, add to cache as well
-        def save
-            tags = {"model" => self.fullname}.merge(self.indexes)
-            pp! tags
-            db = CrystalTwin::Config.db
-            cache = CrystalTwin::Config.cache
-            
-            if self.id == 0 # new
-                self.id = db.put(self.to_yaml, tags)
-                cache.set(self.fullname, self.id.not_nil!, self)
-            else # update
-                db.update(self.id.not_nil!, self.to_yaml, tags)
-                cache.set(self.fullname, self.id.not_nil!, self)
-            end
+    def save
+        tags = {"model" => self.fullname}.merge(self.indexes)
+        pp! tags
+        db = CrystalTwin::Config.db
+        cache = CrystalTwin::Config.cache
+        
+        if self.id == 0 # new
+            self.id = db.put(self.to_yaml, tags)
+            cache.set(self.fullname, self.id.not_nil!, self)
+        else # update
+            db.update(self.id.not_nil!, self.to_yaml, tags)
+            cache.set(self.fullname, self.id.not_nil!, self)
+        end
     end
 
 

--- a/src/crystaltwin.cr
+++ b/src/crystaltwin.cr
@@ -152,26 +152,70 @@ module CrystalTwin
       sub "load" do
         desc "load yaml files into database. Run crystaltwin load --help for more info"
         usage "crystaltwin load [options]"
-        option "-w", "--overwrite",  type: String, desc: "Overwrite if exists"
-        option "-o", "--only",  type: String, desc: "load only this certain file"
-        option "-d DIR", "--dir=DDIR",  type: String, desc: "load files from this dir"
-        option "-m MODEL", "--model=MODEL",  type: String, desc: "load only all files for this model"
+        option "--overwrite",  type: String, desc: "Overwrite if exists"
+        option "--only",  type: String, desc: "load only this certain file"
+        option "--dir=DDIR",  type: String, desc: "load files from this dir"
+        option "--model=MODEL",  type: String, desc: "load only all files for this model"
+        option "--dbsocket=SOCKET", type: String, desc: "Bcdb unix socket file", default: "/tmp/bcdb.sock"
+        option "--dbnamespace", type: String, desc: "Bcdb namespace", default: "crystaltwin"
 
         run do |opts, args|
-          puts "Fake Crystal tool!!"
+          if opts.dir
+            CrystalTwin::Cmd::Load.config data_path: opts.dir.to_s, socketfile: opts.dbsocket, namespace: opts.dbnamespace
+          else
+            CrystalTwin::Cmd::Load.config socketfile: opts.dbsocket, namespace: opts.dbnamespace
+          end
+
+          overwrite_flag = false
+
+          if opts.overwrite
+            overwrite_flag = true
+          end
+
+          if opts.only
+            # ToDO later
+          end
+
+          if opts.model
+            CrystalTwin::Cmd::Load.set_model(opts.model.to_s)
+          end
+
+          CrystalTwin::Cmd::Load.load(overwrite_flag)
         end
       end
 
       sub "dumps" do
         desc "dump yaml files into data directory. Run crystaltwin dump --help for more info"
-        usage "crystaltwin load [options]"
-        option "-w", "--overwrite",  type: String, desc: "Overwrite if exists"
-        option "-d DIR", "--dir=DDIR",  type: String, desc: "dumo files into this dir"
-        option "-m MODEL", "--model=MODEL",  type: String, desc: "dump only files for this model"
-        option "-o ID", "--object=ID",  type: String, desc: "dump only this object"
+        usage "crystaltwin dumps [options]"
+        option "--overwrite",  type: String, desc: "Overwrite if exists"
+        option "--dir=DDIR",  type: String, desc: "dumo files into this dir"
+        option "--model=MODEL",  type: String, desc: "dump only files for this model"
+        option "--object=ID",  type: String, desc: "dump only this object"
+        option "--dbsocket=SOCKET", type: String, desc: "Bcdb unix socket file", default: "/tmp/bcdb.sock"
+        option "--dbnamespace", type: String, desc: "Bcdb namespace", default: "crystaltwin"
 
         run do |opts, args|
-          puts "Fake Crystal tool!!"
+          if opts.dir 
+            CrystalTwin::Cmd::Dumps.config data_path: opts.dir.to_s, socketfile: opts.dbsocket, namespace: opts.dbnamespace
+          else
+            CrystalTwin::Cmd::Dumps.config socketfile: opts.dbsocket, namespace: opts.dbnamespace
+          end
+
+          overwrite_flag = false
+
+          if opts.overwrite
+            overwrite_flag = true
+          end
+
+          if opts.object
+            # ToDO later
+          end
+
+          if opts.model
+            CrystalTwin::Cmd::Dumps.set_model(opts.model.to_s)
+          end
+
+          CrystalTwin::Cmd::Dumps.dumps(overwrite_flag)
         end
       end
     end


### PR DESCRIPTION
## In this PR

- Create Cmd as an app
- Add load and dumps methods and properties in Cmd app.
- Modify load and dumps method according to the last update.
- Add logs for each stage to be clear what happens.
- Edit options in load and dumps commands to use the long method, not the short one to be more descriptive.
- Fix alignment of save method in models
- Update load and dumps to be generic